### PR TITLE
feat: Add Qwen-Image generation support and remove GLM-4.7-Flash backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1181,19 +1181,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "glm47-flash-mlx"
-version = "0.1.0"
-dependencies = [
- "mlx-rs",
- "mlx-rs-core",
- "mlx-sys",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tokenizers 0.21.4",
-]
-
-[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2439,7 +2426,6 @@ dependencies = [
  "eyre",
  "flux-klein-mlx",
  "funasr-mlx",
- "glm47-flash-mlx",
  "gpt-sovits-mlx",
  "hex",
  "hound",
@@ -2447,6 +2433,7 @@ dependencies = [
  "mlx-rs",
  "mlx-rs-core",
  "mlx-sys",
+ "qwen-image-mlx",
  "qwen3-mlx",
  "salvo",
  "serde",
@@ -2873,6 +2860,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "qwen-image-mlx"
+version = "0.25.2"
+dependencies = [
+ "bytemuck",
+ "memmap2",
+ "mlx-macros",
+ "mlx-rs",
+ "mlx-rs-core",
+ "mlx-sys",
+ "safetensors 0.6.2",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokenizers 0.21.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,11 @@ mlx-rs-core = { path = "../OminiX-MLX/mlx-rs-core" }
 
 # Model-specific crates
 qwen3-mlx = { path = "../OminiX-MLX/qwen3-mlx" }
-glm47-flash-mlx = { path = "../OminiX-MLX/glm-4.7-flash-mlx" }
 funasr-mlx = { path = "../OminiX-MLX/funasr-mlx" }
 gpt-sovits-mlx = { path = "../OminiX-MLX/gpt-sovits-mlx" }
 flux-klein-mlx = { path = "../OminiX-MLX/flux-klein-mlx" }
 zimage-mlx = { path = "../OminiX-MLX/zimage-mlx" }
+qwen-image-mlx = { path = "../OminiX-MLX/qwen-image-mlx" }
 
 # Tokenization
 tokenizers = "0.22"

--- a/src/main.rs
+++ b/src/main.rs
@@ -251,6 +251,8 @@ fn inference_thread(
         let lower = model.to_lowercase();
         if lower.contains("flux") {
             "flux"
+        } else if lower.contains("qwen") {
+            "qwen-image"
         } else {
             "zimage"
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -148,6 +148,12 @@ pub struct ImageGenerationRequest {
     /// Strength for img2img (0.0-1.0, higher = more variation from reference)
     #[serde(default = "default_strength")]
     pub strength: f32,
+    /// Number of denoising steps (model-specific default if not set)
+    #[serde(default)]
+    pub steps: Option<u32>,
+    /// Guidance scale for classifier-free guidance
+    #[serde(default)]
+    pub guidance_scale: Option<f32>,
 }
 
 fn default_strength() -> f32 {


### PR DESCRIPTION
## Summary
- Add Qwen-Image 8-bit quantized image generation pipeline (DiT + 3D VAE) with classifier-free guidance, dynamic flow matching schedule, and configurable steps/guidance scale
- Replace `glm47-flash-mlx` dependency with `qwen-image-mlx`; remove temporarily disabled GLM-4.7-Flash LLM backend
- Add `steps` and `guidance_scale` fields to `ImageGenerationRequest` for per-request control

## Test plan
- [ ] Verify Qwen-Image model loads from `qwen-image-8bit` config entry
- [ ] Test text-to-image generation with various prompts, step counts, and guidance scales
- [ ] Confirm FLUX and Z-Image pipelines still work correctly after `Option` refactor
- [ ] Verify img2img correctly rejects Qwen-Image model type
- [ ] Check that GLM-4.7-Flash model references are fully removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)