### PR TITLE
fix(tts): reject unknown voices in /v1/audio/tts/qwen3 with 404

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3973,8 +3973,11 @@ checksum = "3b0978458bee0102c6c337040ea0b13c497ff1e31015c49c2cc9a387f813e2c1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
+ "brotli",
  "bytes 1.11.0",
+ "encoding_rs",
  "enumflags2",
+ "flate2",
  "form_urlencoded",
  "futures-channel",
  "futures-util",
@@ -4000,6 +4003,7 @@ dependencies = [
  "serde",
  "serde-xml-rs",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tempfile",
  "thiserror 2.0.18",
@@ -4007,6 +4011,8 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "tracing",
+ "url",
+ "zstd",
 ]
 
 [[package]]
@@ -5834,6 +5840,34 @@ name = "zmij"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfcd145825aace48cff44a8844de64bf75feec3080e0aa5cdbde72961ae51a65"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,12 @@ image = "0.25"
 # HTTP client (for model downloads)
 reqwest = { version = "0.12", features = ["blocking", "json"] }
 
+[dev-dependencies]
+# Enable salvo's TestClient for handler-level integration tests.
+salvo = { version = "0.81.0", default-features = false, features = [
+    "affix-state", "cors", "server", "http1", "http2", "websocket", "sse", "test"
+] }
+
 [[bin]]
 name = "ominix-api"
 path = "src/main.rs"

--- a/src/handlers/audio.rs
+++ b/src/handlers/audio.rs
@@ -10,7 +10,8 @@ use crate::engines::qwen3_tts;
 use crate::engines::tts_trait::{TtsCloneRequest, TtsRequest as TtsTraitRequest, TtsResponse};
 use crate::error::render_error;
 use crate::inference::{AudioChunk, InferenceRequest, TtsRequest};
-use crate::types::{SpeechCloneRequest, SpeechRequest, TranscriptionRequest};
+use crate::types::{SpeechCloneRequest, SpeechRequest, TranscriptionRequest, VoiceNotFoundError};
+use crate::voice_registry::VoiceRegistry;
 
 use super::helpers::{get_state, send_and_wait};
 
@@ -174,10 +175,41 @@ pub async fn tts_qwen3(
     let wants_wav = req.query::<String>("format").as_deref() == Some("wav")
         || request.response_format == "wav";
 
+    // Resolve the requested voice through the same normalization as before
+    // (empty/"default" -> "vivian"), then reject unknown names with 404.
+    // Silent fallback to a default voice is what prompted this endpoint —
+    // fm_tts callers were getting 200 + audio in the wrong voice because
+    // an unregistered `voice` string was being swallowed downstream.
+    let resolved_voice = normalize_voice(request.voice.clone());
+    let registry = VoiceRegistry::load();
+    if !registry.contains(&resolved_voice) {
+        let requester = request_peer(req);
+        let available = registry.available_voices().to_vec();
+        tracing::info!(
+            "rejected TTS request: unknown voice {} (available: {}) from {}",
+            resolved_voice,
+            available.join(", "),
+            requester,
+        );
+        let message = format!(
+            "Voice '{}' is not registered. Available: {}",
+            resolved_voice,
+            available.join(", "),
+        );
+        res.status_code(salvo::http::StatusCode::NOT_FOUND);
+        res.render(Json(VoiceNotFoundError {
+            error: "voice_not_found",
+            message,
+            requested_voice: resolved_voice,
+            available_voices: available,
+        }));
+        return Ok(());
+    }
+
     let chunk_rx = spawn_per_sentence_tts(
         state.inference_tx.clone(),
         qwen3_tts::split_sentences(&request.input),
-        normalize_voice(request.voice),
+        resolved_voice,
         request.language.unwrap_or_else(|| "chinese".to_string()),
         request.speed,
         request.instruct,
@@ -193,6 +225,30 @@ pub async fn tts_qwen3(
         stream_pcm_response(chunk_rx, res);
     }
     Ok(())
+}
+
+/// Best-effort client identifier for log lines. Prefers
+/// `X-Forwarded-For` / `X-Real-IP` (gateway-provided), else the peer
+/// socket. Falls back to "unknown" so logs stay single-line.
+fn request_peer(req: &Request) -> String {
+    if let Some(fwd) = req.headers().get("x-forwarded-for") {
+        if let Ok(s) = fwd.to_str() {
+            if let Some(first) = s.split(',').next() {
+                let trimmed = first.trim();
+                if !trimmed.is_empty() {
+                    return trimmed.to_string();
+                }
+            }
+        }
+    }
+    if let Some(real) = req.headers().get("x-real-ip") {
+        if let Ok(s) = real.to_str() {
+            if !s.is_empty() {
+                return s.to_string();
+            }
+        }
+    }
+    req.remote_addr().to_string()
 }
 
 /// POST /v1/audio/tts/clone — Qwen3-TTS voice cloning (Base model)
@@ -890,4 +946,194 @@ fn stream_pcm_response(chunk_rx: mpsc::Receiver<AudioChunk>, res: &mut Response)
         .insert("Transfer-Encoding", "chunked".parse().unwrap());
 
     res.stream(stream);
+}
+
+#[cfg(test)]
+mod tests {
+    //! Handler-level tests for `POST /v1/audio/tts/qwen3` voice validation.
+    //!
+    //! These exercise the new 404 behavior without touching the real TTS
+    //! pipeline. The 404 rejection short-circuits before any inference
+    //! request is sent, so a dummy receiver is sufficient.
+    //!
+    //! For happy-path requests (registered voice) the test spawns a stub
+    //! receiver that answers each `SpeechOneSentence` with a tiny PCM
+    //! buffer, mirroring what the real inference thread would produce.
+    use super::*;
+    use crate::inference::TtsRequest as CoreTtsRequest;
+    use crate::state::AppState;
+    use salvo::test::{ResponseExt, TestClient};
+    use serde_json::Value;
+    use std::sync::Arc;
+    use tokio::sync::{broadcast, mpsc};
+
+    /// Build an `AppState` whose `inference_tx` is consumed by a stub
+    /// that answers Qwen3 TTS sentence requests with a 4-byte PCM blob.
+    /// Other channels drop their messages (they're not exercised by
+    /// `tts_qwen3`).
+    fn make_test_state() -> AppState {
+        let (inference_tx, mut inference_rx) = mpsc::channel(8);
+        tokio::spawn(async move {
+            while let Some(req) = inference_rx.recv().await {
+                if let crate::inference::InferenceRequest::Qwen3Tts(tts_req) = req {
+                    match tts_req {
+                        CoreTtsRequest::SpeechOneSentence { response_tx, .. } => {
+                            let _ = response_tx.send(Ok(vec![0u8; 4]));
+                        }
+                        CoreTtsRequest::CloneOneSentence { response_tx, .. } => {
+                            let _ = response_tx.send(Ok(vec![0u8; 4]));
+                        }
+                        CoreTtsRequest::PrepareCloneRef { response_tx, .. } => {
+                            let _ = response_tx.send(Ok(()));
+                        }
+                        CoreTtsRequest::Speech { response_tx, .. } => {
+                            let _ = response_tx.send(Ok(vec![0u8; 4]));
+                        }
+                        CoreTtsRequest::SpeechClone { response_tx, .. } => {
+                            let _ = response_tx.send(Ok(vec![0u8; 4]));
+                        }
+                    }
+                }
+            }
+        });
+        let (training_tx, _training_rx) = mpsc::channel(1);
+        let (progress_tx, _) = broadcast::channel(1);
+        let (download_tx, _download_rx) = mpsc::channel(1);
+        let (download_progress_tx, _) = broadcast::channel(1);
+        AppState {
+            inference_tx,
+            training_tx,
+            progress_tx,
+            cancel_flag: Default::default(),
+            download_tx,
+            download_progress_tx,
+            download_cancel_flags: Default::default(),
+            server_config: Arc::new(crate::server_config::ServerConfig::default()),
+            ascend_config: None,
+            ascend_tts_backend: None,
+        }
+    }
+
+    fn make_test_service() -> salvo::Service {
+        let state = make_test_state();
+        let router = Router::new().push(Router::with_path("v1/audio/tts/qwen3").post(tts_qwen3));
+        let router = router.hoop(salvo::affix_state::inject(state));
+        salvo::Service::new(router)
+    }
+
+    /// Point the registry at a scratch file so tests don't accidentally
+    /// accept voices from the developer's real `~/.OminiX/models/voices.json`.
+    /// Env mutation is serialized by `voice_test_guard`.
+    fn set_voices_json_to_empty() -> tempfile::NamedTempFile {
+        let file = tempfile::NamedTempFile::new().expect("tempfile");
+        std::fs::write(file.path(), r#"{"voices":{}}"#).unwrap();
+        std::env::set_var("OMINIX_VOICES_JSON", file.path());
+        file
+    }
+
+    fn set_voices_json_with(content: &str) -> tempfile::NamedTempFile {
+        let file = tempfile::NamedTempFile::new().expect("tempfile");
+        std::fs::write(file.path(), content).unwrap();
+        std::env::set_var("OMINIX_VOICES_JSON", file.path());
+        file
+    }
+
+    /// Serialize tests that mutate `OMINIX_VOICES_JSON`. A tokio-aware
+    /// mutex is used because the guard is held across await points
+    /// within each test.
+    async fn voice_test_guard() -> tokio::sync::MutexGuard<'static, ()> {
+        use std::sync::OnceLock;
+        use tokio::sync::Mutex;
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(())).lock().await
+    }
+
+    #[tokio::test]
+    async fn should_return_404_when_voice_is_unknown() {
+        let _guard = voice_test_guard().await;
+        let _temp = set_voices_json_to_empty();
+        let service = make_test_service();
+
+        let mut res = TestClient::post("http://127.0.0.1:5800/v1/audio/tts/qwen3")
+            .json(&serde_json::json!({"voice": "yangmi", "input": "test"}))
+            .send(&service)
+            .await;
+
+        assert_eq!(res.status_code.unwrap().as_u16(), 404);
+        let body: Value = res.take_json().await.expect("json body");
+        assert_eq!(body["error"], "voice_not_found");
+        assert_eq!(body["requested_voice"], "yangmi");
+        assert!(
+            body["available_voices"]
+                .as_array()
+                .expect("available_voices array")
+                .iter()
+                .any(|v| v == "vivian"),
+            "expected vivian in available_voices: {body}"
+        );
+        let msg = body["message"].as_str().unwrap();
+        assert!(msg.contains("yangmi"));
+        assert!(msg.contains("vivian"));
+    }
+
+    #[tokio::test]
+    async fn should_return_200_when_voice_is_registered_preset() {
+        let _guard = voice_test_guard().await;
+        let _temp = set_voices_json_to_empty();
+        let service = make_test_service();
+
+        // Ask for WAV so the handler awaits the stub receiver's PCM and
+        // returns a complete body rather than streaming chunked.
+        let res = TestClient::post("http://127.0.0.1:5800/v1/audio/tts/qwen3?format=wav")
+            .json(&serde_json::json!({"voice": "vivian", "input": "hello"}))
+            .send(&service)
+            .await;
+
+        assert_eq!(res.status_code.unwrap().as_u16(), 200);
+    }
+
+    #[tokio::test]
+    async fn should_return_200_when_voice_field_is_missing() {
+        let _guard = voice_test_guard().await;
+        let _temp = set_voices_json_to_empty();
+        let service = make_test_service();
+
+        let res = TestClient::post("http://127.0.0.1:5800/v1/audio/tts/qwen3?format=wav")
+            .json(&serde_json::json!({"input": "hello"}))
+            .send(&service)
+            .await;
+
+        // Empty voice normalizes to "vivian" which is a preset — happy path.
+        assert_eq!(res.status_code.unwrap().as_u16(), 200);
+    }
+
+    #[tokio::test]
+    async fn should_return_200_when_voice_matches_custom_alias() {
+        let _guard = voice_test_guard().await;
+        let _temp = set_voices_json_with(r#"{"voices":{"mia_clone":{"aliases":["mia"]}}}"#);
+        let service = make_test_service();
+
+        let res = TestClient::post("http://127.0.0.1:5800/v1/audio/tts/qwen3?format=wav")
+            .json(&serde_json::json!({"voice": "mia", "input": "hi"}))
+            .send(&service)
+            .await;
+
+        assert_eq!(res.status_code.unwrap().as_u16(), 200);
+    }
+
+    #[test]
+    fn should_include_requested_voice_when_error_serializes() {
+        // Sanity-check the VoiceNotFoundError shape matches the contract.
+        let err = VoiceNotFoundError {
+            error: "voice_not_found",
+            message: "Voice 'x' is not registered. Available: vivian".into(),
+            requested_voice: "x".into(),
+            available_voices: vec!["vivian".into()],
+        };
+        let v: Value = serde_json::from_str(&serde_json::to_string(&err).unwrap()).unwrap();
+        assert_eq!(v["error"], "voice_not_found");
+        assert_eq!(v["requested_voice"], "x");
+        assert_eq!(v["available_voices"][0], "vivian");
+        assert!(v["message"].as_str().unwrap().contains("vivian"));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,7 @@ mod training;
 mod types;
 mod utils;
 mod version;
+mod voice_registry;
 
 use config::Config;
 use inference::{InferenceRequest, TtsPoolConfig};

--- a/src/types/audio.rs
+++ b/src/types/audio.rs
@@ -69,6 +69,22 @@ pub struct SpeechRequest {
 // Audio Speech Clone (Voice Cloning TTS)
 // ============================================================================
 
+/// Response body for a rejected TTS request whose `voice` field did not
+/// match any registered voice. Returned with HTTP 404 from
+/// `POST /v1/audio/tts/qwen3`. See `src/voice_registry.rs`.
+#[derive(Debug, Serialize)]
+pub struct VoiceNotFoundError {
+    /// Stable error tag: always `"voice_not_found"`.
+    pub error: &'static str,
+    /// Human-readable message including the requested voice and a hint
+    /// at the available set.
+    pub message: String,
+    /// Echo of the voice the client asked for.
+    pub requested_voice: String,
+    /// Canonical list of voices the client may request instead.
+    pub available_voices: Vec<String>,
+}
+
 /// Clone request built from multipart form fields (not JSON).
 #[derive(Debug)]
 pub struct SpeechCloneRequest {

--- a/src/voice_registry.rs
+++ b/src/voice_registry.rs
@@ -1,0 +1,193 @@
+//! Voice registry for validating TTS voice names.
+//!
+//! Collects the set of voices the server will actually synthesize for:
+//! the built-in Qwen3-TTS preset speakers plus any custom cloned voices
+//! declared in `~/.OminiX/models/voices.json`. Used to reject
+//! `POST /v1/audio/tts/qwen3` requests whose `voice` field does not match
+//! a registered voice, instead of silently falling back to a default.
+//!
+//! An empty/`"default"` voice is considered valid at the handler level
+//! (the handler substitutes the documented default via `normalize_voice`
+//! before looking up here).
+
+use std::collections::HashSet;
+
+/// Qwen3-TTS CustomVoice preset speaker names (built into the model).
+///
+/// Kept in lockstep with `PRESET_SPEAKERS` in `handlers::training`; any
+/// preset added to the model must be added to both. A future refactor
+/// can unify the two copies without changing behavior.
+const PRESET_SPEAKERS: &[&str] = &[
+    "vivian",
+    "serena",
+    "ryan",
+    "aiden",
+    "uncle_fu",
+    "chinese_woman",
+    "chinese_man",
+    "dialect",
+    "english_man",
+];
+
+/// Default path of the custom-voice registry file.
+const DEFAULT_VOICES_JSON: &str = "~/.OminiX/models/voices.json";
+
+/// Environment variable that overrides `DEFAULT_VOICES_JSON`. Primarily
+/// for tests and operators who store the voices file elsewhere.
+const VOICES_JSON_ENV: &str = "OMINIX_VOICES_JSON";
+
+/// Registry of voices the TTS backend will accept.
+#[derive(Debug, Clone)]
+pub struct VoiceRegistry {
+    /// Canonical voice names — preset speakers plus custom names declared in
+    /// `voices.json`. Ordering: presets first (registry order), then customs
+    /// in JSON-iteration order.
+    canonical_names: Vec<String>,
+    /// Lookup keys: every canonical name plus every alias. Case-sensitive
+    /// to match the existing model behavior (Qwen3-TTS preset names are
+    /// lowercase by convention).
+    valid_keys: HashSet<String>,
+}
+
+impl VoiceRegistry {
+    /// Load the registry from the default location
+    /// (`~/.OminiX/models/voices.json`, or the path in the
+    /// `OMINIX_VOICES_JSON` env var when set). Missing or malformed JSON
+    /// is tolerated — the registry still includes the preset speakers.
+    pub fn load() -> Self {
+        let path = std::env::var(VOICES_JSON_ENV)
+            .unwrap_or_else(|_| crate::utils::expand_tilde(DEFAULT_VOICES_JSON));
+        Self::load_from_path(&path)
+    }
+
+    /// Load the registry from an explicit path. Exposed for tests.
+    pub fn load_from_path(path: &str) -> Self {
+        let custom_json = std::fs::read_to_string(path)
+            .ok()
+            .and_then(|content| serde_json::from_str::<serde_json::Value>(&content).ok());
+        Self::from_json(custom_json.as_ref())
+    }
+
+    /// Build the registry from optional custom-voice JSON (the raw
+    /// contents of `voices.json`).
+    fn from_json(custom: Option<&serde_json::Value>) -> Self {
+        let mut canonical_names: Vec<String> =
+            PRESET_SPEAKERS.iter().map(|s| s.to_string()).collect();
+        let mut valid_keys: HashSet<String> = canonical_names.iter().cloned().collect();
+
+        if let Some(config) = custom {
+            if let Some(voices) = config.get("voices").and_then(|v| v.as_object()) {
+                for (name, voice) in voices {
+                    canonical_names.push(name.clone());
+                    valid_keys.insert(name.clone());
+                    if let Some(aliases) = voice.get("aliases").and_then(|a| a.as_array()) {
+                        for alias in aliases.iter().filter_map(|v| v.as_str()) {
+                            valid_keys.insert(alias.to_string());
+                        }
+                    }
+                }
+            }
+        }
+
+        Self {
+            canonical_names,
+            valid_keys,
+        }
+    }
+
+    /// Return `true` when `voice` matches a registered canonical name or
+    /// alias. Case-sensitive.
+    pub fn contains(&self, voice: &str) -> bool {
+        self.valid_keys.contains(voice)
+    }
+
+    /// Canonical list of voices for client-facing error messages.
+    pub fn available_voices(&self) -> &[String] {
+        &self.canonical_names
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn registry_with_custom(json: serde_json::Value) -> VoiceRegistry {
+        VoiceRegistry::from_json(Some(&json))
+    }
+
+    #[test]
+    fn should_accept_preset_speakers_when_no_custom_voices() {
+        let reg = VoiceRegistry::from_json(None);
+        assert!(reg.contains("vivian"));
+        assert!(reg.contains("serena"));
+        assert!(reg.contains("english_man"));
+    }
+
+    #[test]
+    fn should_reject_unknown_voice_when_not_registered() {
+        let reg = VoiceRegistry::from_json(None);
+        assert!(!reg.contains("yangmi"));
+        assert!(!reg.contains("does_not_exist"));
+    }
+
+    #[test]
+    fn should_accept_custom_voice_when_declared_in_json() {
+        let reg = registry_with_custom(serde_json::json!({
+            "voices": {
+                "yangmi": {"aliases": []}
+            }
+        }));
+        assert!(reg.contains("yangmi"));
+    }
+
+    #[test]
+    fn should_accept_alias_when_declared_in_json() {
+        let reg = registry_with_custom(serde_json::json!({
+            "voices": {
+                "vivian_clone": {"aliases": ["vivian2", "vivian-new"]}
+            }
+        }));
+        assert!(reg.contains("vivian_clone"));
+        assert!(reg.contains("vivian2"));
+        assert!(reg.contains("vivian-new"));
+    }
+
+    #[test]
+    fn should_be_case_sensitive_when_matching_voice() {
+        let reg = VoiceRegistry::from_json(None);
+        assert!(reg.contains("vivian"));
+        assert!(!reg.contains("Vivian"));
+        assert!(!reg.contains("VIVIAN"));
+    }
+
+    #[test]
+    fn should_list_presets_first_in_available_voices() {
+        let reg = registry_with_custom(serde_json::json!({
+            "voices": {"custom_a": {"aliases": []}}
+        }));
+        let names = reg.available_voices();
+        assert_eq!(names[0], "vivian");
+        assert!(names.iter().any(|n| n == "custom_a"));
+        // Customs appear after all presets.
+        let custom_idx = names.iter().position(|n| n == "custom_a").unwrap();
+        assert!(custom_idx >= PRESET_SPEAKERS.len());
+    }
+
+    #[test]
+    fn should_tolerate_malformed_voices_json_when_loading() {
+        // Point at a file that does not exist — should still list presets.
+        let reg = VoiceRegistry::load_from_path("/nonexistent/voices.json");
+        assert!(reg.contains("vivian"));
+        assert!(!reg.contains("yangmi"));
+    }
+
+    #[test]
+    fn should_tolerate_voices_without_aliases_field() {
+        let reg = registry_with_custom(serde_json::json!({
+            "voices": {
+                "no_alias_voice": {}
+            }
+        }));
+        assert!(reg.contains("no_alias_voice"));
+    }
+}


### PR DESCRIPTION
## Summary

- `POST /v1/audio/tts/qwen3` previously accepted any `voice` string and let the TTS backend silently fall back to a default. Callers whose requested voice was never registered would get `200 OK` + audio in the wrong voice, with no way to tell.
- This PR validates the `voice` field against a registry of preset speakers + custom voices (from `~/.OminiX/models/voices.json`) and returns `404` with a structured error body when the voice is unknown. Empty/missing/`"default"` voice still resolves to the documented default (`vivian`).
- Logs the rejection at INFO with the requesting IP; `/v1/voices` listing and the TTS synthesis engine are untouched.

## Observed symptom

On octos mini2, `ominix-api` reports `{"voices":[]}` (no custom voices registered). fm_tts calls with `voice=yangmi` return `200 OK` with a valid WAV — but in `vivian`'s voice, not `yangmi`. The LLM layer sees success and tells the user the clip is ready, so the wrong voice is surfaced to the end user. After this change fm_tts will start receiving 404 errors from unknown voices, which is the point — octos layers above will surface them.

## Response shape (404)

```json
{
  "error": "voice_not_found",
  "message": "Voice 'yangmi' is not registered. Available: vivian, serena, ...",
  "requested_voice": "yangmi",
  "available_voices": ["vivian", "serena", "ryan", "..."]
}
```

## Backward compatibility

No client migration is required on octos's side. Clients that omit the `voice` field continue to work (empty -> default voice). Only clients that currently request a voice the server does not expose will see a new 404 instead of a wrong-voice 200 — which is the intended behavior.

## Test plan

- [x] `cargo test` — 22 tests pass (13 new, including 4 handler-level integration tests via salvo's `TestClient`)
  - 404 response with correct body shape for unknown voice
  - 200 for registered preset (`vivian`)
  - 200 for missing voice field (default path preserved)
  - 200 for custom voice alias lookup
- [x] `cargo clippy --tests --bin ominix-api` — no new warnings
- [x] `cargo build` — clean
- [ ] Deploy to octos mini2 and verify `POST /v1/audio/tts/qwen3 {voice:"yangmi"}` now returns 404