### PR TITLE
feat(asr): keep Qwen3-ASR warm to avoid cold-start latency

### DIFF
--- a/src/engines/asr.rs
+++ b/src/engines/asr.rs
@@ -168,6 +168,44 @@ impl AsrEngine {
             }
         }
     }
+
+    /// Run one short dummy inference so the first real request doesn't pay the
+    /// MLX graph-compilation cost (~5s for Qwen3-ASR). Errors are non-fatal.
+    pub fn warmup(&mut self) {
+        // Low-amplitude tone, NOT silence: all-zero input drives Qwen3-ASR's
+        // mel/encoder into a degenerate state that hangs the decode.
+        let samples: Vec<f32> = (0..16000)
+            .map(|i| 0.02f32 * (i as f32 * 0.06f32).sin())
+            .collect(); // ~1s @ 16kHz
+        let result: Result<()> = match &mut self.backend {
+            AsrBackend::Paraformer { model, vocab } => {
+                let mut model = model.clone();
+                funasr_mlx::transcribe(&mut model, &samples, vocab)
+                    .map(|_| ())
+                    .context("Paraformer warmup failed")
+            }
+            AsrBackend::SenseVoiceQwen { model } => model
+                .transcribe_samples(&samples, 16000)
+                .map(|_| ())
+                .map_err(|e| eyre::eyre!("{:?}", e)),
+            AsrBackend::Qwen3Asr { model } => {
+                let config = qwen3_asr_mlx::SamplingConfig {
+                    max_tokens: 4,
+                    ..Default::default()
+                };
+                let r = model
+                    .transcribe_samples_with_config(&samples, "Chinese", &config)
+                    .map(|_| ())
+                    .map_err(|e| eyre::eyre!("{:?}", e));
+                unsafe { mlx_sys::mlx_clear_cache(); }
+                r
+            }
+        };
+        match result {
+            Ok(_) => tracing::info!("ASR warmup complete"),
+            Err(e) => tracing::warn!("ASR warmup failed (non-fatal): {}", e),
+        }
+    }
 }
 
 /// Decode audio from request: accepts a local file path (starts with '/') or base64-encoded audio.

--- a/src/inference/request.rs
+++ b/src/inference/request.rs
@@ -93,6 +93,9 @@ pub enum InferenceRequest {
     },
     /// Qwen3-TTS request (routed through inference queue to serialize GPU access)
     Qwen3Tts(super::tts_pool::TtsRequest),
+    /// Fire-and-forget: re-run a short ASR inference to keep the MLX graph /
+    /// model pages warm so the first real request after idle isn't cold.
+    KeepWarmAsr,
 }
 
 /// Current status of all models

--- a/src/inference/thread.rs
+++ b/src/inference/thread.rs
@@ -73,6 +73,11 @@ pub fn inference_thread(
                 if let Some(ref engine) = asr_engine {
                     current_asr_model = Some(engine.backend_name().to_string());
                 }
+                // Warm up so the first real request doesn't pay MLX graph
+                // compilation (~5s for Qwen3-ASR).
+                if let Some(ref mut engine) = asr_engine {
+                    engine.warmup();
+                }
             }
             Err(e) => tracing::warn!("Failed to load ASR model: {}", e),
         }
@@ -356,6 +361,12 @@ pub fn inference_thread(
             // Qwen3-TTS (serialized through the same queue as ASR/LLM)
             InferenceRequest::Qwen3Tts(tts_request) => {
                 qwen3_tts.handle(tts_request);
+            }
+            // Periodic keep-warm so the first ASR after idle isn't cold.
+            InferenceRequest::KeepWarmAsr => {
+                if let Some(ref mut engine) = asr_engine {
+                    engine.warmup();
+                }
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,6 +115,23 @@ async fn main() -> eyre::Result<()> {
         .context("Failed to receive ready signal from inference thread")?;
     tracing::info!("Inference thread ready");
 
+    // Keep ASR warm: periodically re-run a short inference so the MLX graph /
+    // model pages aren't released after idle (first-after-idle cold start is
+    // otherwise ~5s). No-op when no ASR model is configured.
+    if !config.asr_model_dir.is_empty() {
+        let warm_tx = inference_tx.clone();
+        tokio::spawn(async move {
+            let mut tick = tokio::time::interval(std::time::Duration::from_secs(180));
+            tick.tick().await; // consume the immediate first tick (startup already warmed)
+            loop {
+                tick.tick().await;
+                if warm_tx.send(InferenceRequest::KeepWarmAsr).await.is_err() {
+                    break; // inference thread shut down
+                }
+            }
+        });
+    }
+
     // // Initialize Ascend backend if configured via environment
     // let ascend_config = engines::ascend::AscendConfig::from_env().map(|cfg| {
     //     tracing::info!("Ascend backend configured: bin_dir={}", cfg.bin_dir.display());


### PR DESCRIPTION
## Summary

The first ASR request after startup — and after any idle period — pays ~5s of MLX graph compilation / model-page reload, which dominates the voice round-trip latency. This adds a warmup path that pre-compiles the graph and keeps the model resident.

## Changes

- **`AsrEngine::warmup()`**: runs one ~1s low-amplitude tone inference to pre-compile the MLX graph. Uses a tone rather than silence on purpose — all-zero input drives Qwen3-ASR's mel/encoder into a degenerate state that hangs the decode. Errors are non-fatal.
- Warmup is invoked right after the ASR model loads on the inference thread.
- New **`InferenceRequest::KeepWarmAsr`** variant, handled on the inference thread, re-runs `warmup()` so idle doesn't release the graph/pages.
- `main.rs` spawns a 180s ticker that sends `KeepWarmAsr`. No-op when no ASR model is configured.

## Notes

- Independent of #45 (ffmpeg deadlock fix); touches different functions. Both target `main`.
- No behavior change when `asr_model_dir` is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)